### PR TITLE
Hotfix - Display moon only after sunset

### DIFF
--- a/dist/meteo-france-weather-card.js
+++ b/dist/meteo-france-weather-card.js
@@ -5,7 +5,8 @@ const html = LitElement.prototype.html;
 
 const weatherIconsDay = {
   clear: "day",
-  "clear-night": "night",
+  "clear-night": "day",
+  "nuit claire": "day",
   cloudy: "cloudy",
   fog: "cloudy",
   hail: "rainy-7",
@@ -25,6 +26,7 @@ const weatherIconsDay = {
 const weatherIconsNight = {
   ...weatherIconsDay,
   clear: "night",
+  "clear-night": "night",
   sunny: "night",
   "nuit claire": "night",
   partlycloudy: "cloudy-night-3",


### PR DESCRIPTION
Metéo France chose to display sun between 7am and 7pm and moon between 7pm and 7am, it's strange in summer to display moon at 8pm while sun shines…

This project already corrects this problem but a small error remains in it.

Here it is the small correction.

Link to issue #5 