### PR TITLE
Support hour mode

### DIFF
--- a/dist/meteo-france-weather-card.js
+++ b/dist/meteo-france-weather-card.js
@@ -155,7 +155,7 @@ function processForecast(lang, forecast) {
       }
 
       processedForecast.push({
-        date: hourMode ? date.toLocaleTimeString(lang, {hour: "2-digit"}) : date.toLocaleDateString(lang, {weekday: "short"}),
+        formattedDate: hourMode ? date.toLocaleTimeString(lang, {hour: "2-digit"}) : date.toLocaleDateString(lang, {weekday: "short"}),
         condition: forecast[i].condition.toLowerCase(),
         temperature: forecast[i].temperature,
         templow : forecast[i].templow,
@@ -207,7 +207,6 @@ class WeatherCard extends LitElement {
     const alertObj = this.hass.states[this._config.alertEntity];
     const rainForecastObj = this.hass.states[this._config.rainForecastEntity];
     const uvObj = this.hass.states[this._config.uvEntity];
-    const processedForecast = processForecast(stateObj.attributes.forecast);
 
     if (!stateObj) {
       return html`
@@ -227,6 +226,7 @@ class WeatherCard extends LitElement {
     }
 
     const lang = this.hass.selectedLanguage || this.hass.language;
+    const processedForecast = processForecast(lang, stateObj.attributes.forecast);
 
     const next_rising = new Date(
       this.hass.states["sun.sun"].attributes.next_rising

--- a/dist/meteo-france-weather-card.js
+++ b/dist/meteo-france-weather-card.js
@@ -135,7 +135,6 @@ function hasConfigOrEntityChanged(element, changedProps) {
 }
 
 function processForecast(lang, forecast) {
-  console.log(forecast);
   if (forecast === undefined || forecast.length == 0) {
     return [];
   } else {


### PR DESCRIPTION
A small MR to add support for "hourly" mode of MétéoFrance integration.
By default, MétéoFrance integration is setup as daily, but you can switch to hourly:
![image](https://user-images.githubusercontent.com/46689813/221373398-b06d0053-5c0b-4fbd-b607-0f33d8e461a5.png)

My pull request correctly format the "date" field for forecast:
![image](https://user-images.githubusercontent.com/46689813/221373283-66de85eb-3757-4259-af9f-40832afe9022.png)
Without this change, it is showing only the day of week (which is obviously the same for the next 5 hours)

:warning: Not related, but there is an issue on firefox with the latest version.
It can be fixed by either reverting d03d5f81bcda3c401b6acb0f0984f208f35b7247 or merging https://github.com/Imbuzi/meteo-france-weather-card/pull/26